### PR TITLE
Fix: Android keyboard area calculation.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = '1.3.11'
+        kotlinVersion = '1.4.10'
         androidToolsVersion = '3.2.1'
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = '1.4.10'
+        kotlinVersion = '1.4.21'
         androidToolsVersion = '3.2.1'
     }
 


### PR DESCRIPTION
First of all, thank you so much for the great library. You are the life saver of my project.
Full credit for that fixes belong to the owner of this repository https://github.com/Crysis21/KeyboardHeightProvider. I'm just searching around and contribute a PR as my thank.

Changelogs:
- Fixed android keyboard area calculation in horizontal mode
- Added precise keyboard area calculation for android devices with notches.

